### PR TITLE
Cleanup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+	"trailingComma": "es5",
+	"singleQuote": true,
+	"semi": false,
+	"printWidth": 100,
+	"tabWidth": 2,
+	"useTabs": true
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+**Try this out at [makereal.tldraw.com](https://makereal.tldraw.com/)!**
+
 > This is an experimental fork of Sawyer Hood's [draw a ui](https://github.com/SawyerHood/draw-a-ui).
 > Hopefully some of these changes can make it upstream!
+>
 > - Changes the preview to an embedded shape that appears on the canvas.
 > - Only selected shapes are used when generating html.
 > - One embedded preview can be given back to GPT, with annotations.
@@ -21,8 +24,8 @@ This is a Next.js app. To get started run the following commands in the root dir
 
 ```bash
 echo "OPENAI_API_KEY=sk-your-key" > .env.local
-npm install
-npm run dev
+yarn
+yarn dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-**Try this out at [makereal.tldraw.com](https://makereal.tldraw.com/)!**
+**Try it out at [makereal.tldraw.com](https://makereal.tldraw.com/).**
+
+\*\*To use your own API key, you need to have access to usage tier 1. Check out your current tier, and how to increase it [in the OpenAI settings](http://platform.openai.com/account/limits).
 
 > This is an experimental fork of Sawyer Hood's [draw a ui](https://github.com/SawyerHood/draw-a-ui).
 > Hopefully some of these changes can make it upstream!

--- a/app/PreviewShape/PreviewShape.tsx
+++ b/app/PreviewShape/PreviewShape.tsx
@@ -5,8 +5,6 @@ import {
 	useIsEditing,
 	HTMLContainer,
 	toDomPrecision,
-	SvgExportContext,
-	TLFrameShape,
 	Icon,
 	useToasts,
 	stopEventPropagation,

--- a/app/components/APIKeyInput.tsx
+++ b/app/components/APIKeyInput.tsx
@@ -1,13 +1,9 @@
-import { Input, useBreakpoint } from '@tldraw/tldraw'
+import { useBreakpoint } from '@tldraw/tldraw'
 
 export function APIKeyInput() {
 	const breakpoint = useBreakpoint()
 	return (
-		<div
-			className={`your-own-api-key ${
-				breakpoint < 5 ? 'your-own-api-key__mobile' : ''
-			}`}
-		>
+		<div className={`your-own-api-key ${breakpoint < 5 ? 'your-own-api-key__mobile' : ''}`}>
 			<div className="your-own-api-key__inner">
 				<div>Have your own OpenAI API key?</div>
 				<div className="input__wrapper">

--- a/app/components/APIKeyInput.tsx
+++ b/app/components/APIKeyInput.tsx
@@ -7,7 +7,7 @@ export function APIKeyInput() {
 			<div className="your-own-api-key__inner">
 				<div>Have your own OpenAI API key?</div>
 				<div className="input__wrapper">
-					<input type="password" id="openai_key_risky_but_cool" />
+					<input id="openai_key_risky_but_cool" />
 				</div>
 			</div>
 		</div>

--- a/app/components/APIKeyInput.tsx
+++ b/app/components/APIKeyInput.tsx
@@ -7,7 +7,7 @@ export function APIKeyInput() {
 			<div className="your-own-api-key__inner">
 				<div>Have your own OpenAI API key?</div>
 				<div className="input__wrapper">
-					<input id="openai_key_risky_but_cool" />
+					<input type="password" id="openai_key_risky_but_cool" />
 				</div>
 			</div>
 		</div>

--- a/app/components/ExportButton.tsx
+++ b/app/components/ExportButton.tsx
@@ -1,9 +1,4 @@
-import {
-	useEditor,
-	getSvgAsImage,
-	useToasts,
-	createShapeId,
-} from '@tldraw/tldraw'
+import { useEditor, getSvgAsImage, useToasts, createShapeId } from '@tldraw/tldraw'
 import { useState } from 'react'
 import { PreviewShape } from '../PreviewShape/PreviewShape'
 
@@ -39,9 +34,7 @@ export function ExportButton() {
 					}) as PreviewShape[]
 
 					if (previousPreviews.length > 1) {
-						throw new Error(
-							'You can only give the developer one previous design to work with.'
-						)
+						throw new Error('You can only give the developer one previous design to work with.')
 					}
 
 					const previousHtml =
@@ -54,9 +47,7 @@ export function ExportButton() {
 						return
 					}
 
-					const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(
-						navigator.userAgent
-					)
+					const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
 					const blob = await getSvgAsImage(svg, IS_SAFARI, {
 						type: 'png',
@@ -84,11 +75,8 @@ export function ExportButton() {
 							image: dataUrl,
 							html: previousHtml,
 							apiKey:
-								(
-									document.getElementById(
-										'openai_key_risky_but_cool'
-									) as HTMLInputElement
-								)?.value ?? null,
+								(document.getElementById('openai_key_risky_but_cool') as HTMLInputElement)?.value ??
+								null,
 						}),
 					})
 

--- a/app/components/ExportButton.tsx
+++ b/app/components/ExportButton.tsx
@@ -21,8 +21,9 @@ export function ExportButton() {
 						toast.addToast({
 							title: 'Nothing selected',
 							description: 'First select something to make real.',
-							id: 'nothing_selected',
+							id: 'nothing_selected: First select something to make real.',
 						})
+						return
 					}
 
 					const previewPosition = selectedShapes.reduce(
@@ -43,7 +44,13 @@ export function ExportButton() {
 					}) as PreviewShape[]
 
 					if (previousPreviews.length > 1) {
-						throw new Error('You can only give the developer one previous design to work with.')
+						toast.addToast({
+							title: 'Too many previous designs',
+							description:
+								'Currently, you can only give the developer one previous design to work with.',
+							id: 'too_many_previous_designs',
+						})
+						return
 					}
 
 					const previousHtml =

--- a/app/components/ExportButton.tsx
+++ b/app/components/ExportButton.tsx
@@ -16,6 +16,15 @@ export function ExportButton() {
 					e.preventDefault()
 
 					const selectedShapes = editor.getSelectedShapes()
+
+					if (selectedShapes.length === 0) {
+						toast.addToast({
+							title: 'Nothing selected',
+							description: 'First select something to make real.',
+							id: 'nothing_selected',
+						})
+					}
+
 					const previewPosition = selectedShapes.reduce(
 						(acc, shape) => {
 							const bounds = editor.getShapePageBounds(shape)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,11 +66,7 @@ export const metadata: Metadata = {
 
 const inter = Inter({ subsets: ['latin'] })
 
-export default function RootLayout({
-	children,
-}: {
-	children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en">
 			<head>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 'use client'
-import Lockup from './lockup.svg'
 
 import dynamic from 'next/dynamic'
 import '@tldraw/tldraw/tldraw.css'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { PreviewShapeUtil } from './PreviewShape/PreviewShape'
 import { ExportButton } from './components/ExportButton'
-import { useBreakpoint, useDialogs, useEditor } from '@tldraw/tldraw'
+import { useBreakpoint } from '@tldraw/tldraw'
 import { APIKeyInput } from './components/APIKeyInput'
+import Image from 'next/image'
 
 const Tldraw = dynamic(async () => (await import('@tldraw/tldraw')).Tldraw, {
 	ssr: false,
@@ -20,11 +20,7 @@ export default function Home() {
 	return (
 		<>
 			<div className={'tldraw__editor'}>
-				<Tldraw
-					persistenceKey="tldraw"
-					shapeUtils={shapeUtils}
-					shareZone={<ExportButton />}
-				>
+				<Tldraw persistenceKey="tldraw" shapeUtils={shapeUtils} shareZone={<ExportButton />}>
 					<APIKeyInput />
 					<LockupLink />
 				</Tldraw>
@@ -40,7 +36,8 @@ function LockupLink() {
 			className={`lockup__link ${breakpoint < 5 ? 'lockup__link__mobile' : ''}`}
 			href="https://www.tldraw.dev"
 		>
-			<img
+			<Image
+				alt="tldraw logo"
 				className="lockup"
 				src="/lockup.svg"
 				style={{ padding: 8, height: 40 }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 /* eslint-disable react-hooks/rules-of-hooks */
 'use client'
 
@@ -8,7 +9,6 @@ import { PreviewShapeUtil } from './PreviewShape/PreviewShape'
 import { ExportButton } from './components/ExportButton'
 import { useBreakpoint } from '@tldraw/tldraw'
 import { APIKeyInput } from './components/APIKeyInput'
-import Image from 'next/image'
 
 const Tldraw = dynamic(async () => (await import('@tldraw/tldraw')).Tldraw, {
 	ssr: false,
@@ -36,7 +36,7 @@ function LockupLink() {
 			className={`lockup__link ${breakpoint < 5 ? 'lockup__link__mobile' : ''}`}
 			href="https://www.tldraw.dev"
 		>
-			<Image
+			<img
 				alt="tldraw logo"
 				className="lockup"
 				src="/lockup.svg"

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "draw-a-ui",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "@tldraw/tldraw": "^2.0.0-canary.81f6fae070ad",
-    "@vercel/analytics": "^1.1.1",
-    "canvas-size": "^1.2.6",
-    "html2canvas": "^1.4.1",
-    "next": "14.0.1",
-    "prismjs": "^1.29.0",
-    "react": "^18",
-    "react-dom": "^18"
-  },
-  "devDependencies": {
-    "@types/canvas-size": "^1.2.1",
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "autoprefixer": "^10.0.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.0.1",
-    "postcss": "^8",
-    "tailwindcss": "^3.3.0",
-    "typescript": "^5"
-  }
+	"name": "draw-a-ui",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint"
+	},
+	"dependencies": {
+		"@tldraw/tldraw": "^2.0.0-canary.81f6fae070ad",
+		"@vercel/analytics": "^1.1.1",
+		"canvas-size": "^1.2.6",
+		"html2canvas": "^1.4.1",
+		"next": "14.0.1",
+		"prismjs": "^1.29.0",
+		"react": "^18",
+		"react-dom": "^18"
+	},
+	"devDependencies": {
+		"@types/canvas-size": "^1.2.1",
+		"@types/node": "^20",
+		"@types/react": "^18",
+		"@types/react-dom": "^18",
+		"autoprefixer": "^10.0.1",
+		"eslint": "^8",
+		"eslint-config-next": "14.0.1",
+		"postcss": "^8",
+		"tailwindcss": "^3.3.0",
+		"typescript": "^5"
+	}
 }


### PR DESCRIPTION
This PR...

- Adds a prettier config file and formats stuff. (Copied it from brivate).
- Updates the readme.
- Gets rid of a next warning.
- Shows a toast when the user tries to 'make real' from nothing.
- Shows a toast when the user tries to 'make real' from more than one previous preview shape.
- ~~Changes the API key input to a password so that it hides its contents.~~ This makes password managers freak out and suggest inputs for text shapes.