### PR TITLE
use type password on api key input

### DIFF
--- a/app/components/APIKeyInput.tsx
+++ b/app/components/APIKeyInput.tsx
@@ -16,6 +16,7 @@ export function APIKeyInput() {
 			<div className="your-own-api-key__inner">
 				<div className="input__wrapper">
 					<input
+						type="password"
 						id="openai_key_risky_but_cool"
 						defaultValue={localStorage.getItem('makeitreal_key') ?? ''}
 						onChange={handleChange}


### PR DESCRIPTION
API Key is a confidential data that should not be shown publicly, especially when we want to record the screen while trying to copy-paste the API Key to the website.